### PR TITLE
remove errors Nokogiri errors

### DIFF
--- a/lib/extended_content.rb
+++ b/lib/extended_content.rb
@@ -715,9 +715,7 @@ require 'xmlsimple'
             )
           end
 
-        # end
-        # ROB: I was having problems with Nokogiri blowing up with this.
-        end.flatten.uniq.join("\n")
+        end
 
         # OLD_KETE_TODO: For some reason a bunch of duplicate extended fields are created. Work out why.
 


### PR DESCRIPTION
This code makes tries to do flatten operations on an array of
Nokogiri::XML::Builder::NodeBuilder objects created by Nokogiri
xml.send calls. These are superfluous given that the join call
creates a string which is promptly ignored and a
builder.to_stripped_xml() call is used to get the string returned.

Basically I it seems completely pointless and isn't the way Nokogiri
works. But I may be missing something.

This fixes a no-method: flatten error stopping Topics being saved.
