### PR TITLE
Rr/rmv caching

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -120,9 +120,6 @@ class ApplicationController < ActionController::Base
   # by posting a dummy form
   before_filter :current_user_can_see_action_menu?, :only => [:new, :create, :edit, :update]
 
-  # creates a @cache_id variable based on params[:id]
-  before_filter :set_cache_id, :only => [:show]
-
   # TODO: NOT USED, delete code here and in lib/zoom_controller_helpers.rb
   # related items only track title and url, therefore only update will change those attributes
   after_filter :update_zoom_record_for_related_items, :only => [ :update ]
@@ -147,10 +144,6 @@ class ApplicationController < ActionController::Base
 
   helper :slideshows
   helper :extended_fields
-
-  def set_cache_id
-    @cache_id = params[:id] ? params[:id].to_i : nil
-  end
 
   # set the current basket to the default
   # unless we have urlified_name that is different

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -677,17 +677,18 @@ module ApplicationHelper
     {class: class_names.join(' '), style: styles.join }
   end
 
-  def related_items_count_for_current_item
+  def related_items_count_for_current_item(item)
     @related_items_count_for_current_item ||= begin
-      cache_id = @cache_id
-      class_name = zoom_class_from_controller(params[:controller])
-      unless cache_id
-        cache_id = @topic.id if @topic.present?
+      if item
+        item_id = item.id
+        class_name = zoom_class_from_controller(params[:controller])
+      else
+        item_id = @topic.id if @topic.present?
         class_name = 'Topic' if class_name == 'IndexPage'
       end
-      conditions = "(content_item_relations.related_item_id = :cache_id AND content_item_relations.related_item_type = '#{class_name}')"
-      conditions += " OR (content_item_relations.topic_id = :cache_id)" if params[:controller] == 'topics' || params[:controller] == 'index_page'
-      ContentItemRelation.count(:conditions => [conditions, { :cache_id => cache_id }])
+      conditions = "(content_item_relations.related_item_id = :item_id AND content_item_relations.related_item_type = '#{class_name}')"
+      conditions += " OR (content_item_relations.topic_id = :item_id)" if params[:controller] == 'topics' || params[:controller] == 'index_page'
+      ContentItemRelation.count(:conditions => [conditions, { :item_id => item_id }])
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1439,31 +1439,6 @@ module ApplicationHelper
     end
   end
 
-  # Kieran Pilkington, 2008/07/28
-  # DEPRECATED, points to cache_with_privacy
-  def cache_if_public(item, name = {}, options = nil, &block)
-    cache_with_privacy(item, name, options, &block)
-  end
-
-  # Kieran Pilkinton, 2008/07/28
-  # Cache block with the privacy value
-  # Different blocks have different values for public and private version
-  # If something shares data, just use rails cache method
-  # item can be nil
-  # but this assumes that item is not nil when item is private
-  def cache_with_privacy(item, name = {}, options = nil, &block)
-    privacy_value = (!item.blank? && item.respond_to?(:private) && item.private?) ? "private" : "public"
-    name.each { |key,value| name[key] = "#{value}_#{privacy_value}" }
-
-    # item is nil when we are loading from cache,
-    # so always use params[:id]
-    # strip out title from passed id
-    # (.to_i will only return 123 when passed id is "123-some-title")
-    # if we have an id for this page
-    name[:id] = params[:id].to_i unless params[:id].blank?
-    cache(name, options, &block)
-  end
-
   # Check if privacy controls should be displayed?
   def show_privacy_controls?(basket = @current_basket)
     basket.show_privacy_controls_with_inheritance?

--- a/app/views/audio/show.html.haml
+++ b/app/views/audio/show.html.haml
@@ -6,8 +6,7 @@
   #main-content-wrapper
     #main-content-container
       %a{:name => "main-content"}
-      - cache_with_privacy(@audio_recording, {:part => 'details_first'}) do
-        %h2= h(@audio_recording.title)
+      %h2= h(@audio_recording.title)
 
       = extras_after_title_headline
 
@@ -15,9 +14,9 @@
 
       = render(:partial => "details", :locals => { :item => @audio_recording }) if show_attached_files_for?(@audio_recording)
 
-      - cache_with_privacy(@audio_recording, {:part => 'details_second'}) do
-        %p= @audio_recording.description.html_safe
-        = pending_review(@audio_recording)
+
+      %p= @audio_recording.description.html_safe
+      = pending_review(@audio_recording)
 
       = render(:partial => "topics/extended_fields", :locals => { :item => @audio_recording, :embedded => true })
       %div{:style => "clear:both;"}

--- a/app/views/documents/show.html.haml
+++ b/app/views/documents/show.html.haml
@@ -6,8 +6,7 @@
   #main-content-wrapper
     #main-content-container
       %a{:name => "main-content"}
-      - cache_with_privacy(@document, { :part => 'details_first' }) do
-        %h2= h(@document.title)
+      %h2= h(@document.title)
 
       = extras_after_title_headline
       %p
@@ -17,9 +16,8 @@
 
       = render(:partial => "details", :locals => { :item => @document }) if show_attached_files_for?(@document)
 
-      - cache_with_privacy(@document, { :part => 'details_second' }) do
-        %p= @document.description.html_safe
-        = pending_review(@document)
+      %p= @document.description.html_safe
+      = pending_review(@document)
 
       = render(:partial => "topics/extended_fields", :locals => { :item => @document, :embedded => true })
       %div{:style => "clear:both;"}

--- a/app/views/images/show.html.haml
+++ b/app/views/images/show.html.haml
@@ -6,8 +6,7 @@
   #main-content-wrapper
     #main-content-container
       %a{:name => "main-content"}
-      - cache_with_privacy(@still_image, {:part => 'details_first'}) do
-        %h2= h(@still_image.title)
+      %h2= h(@still_image.title)
       = extras_after_title_headline
 
       = render(:partial => "topics/related_items", :locals => { :item => @still_image, :related_items => @related_item_topics, :position => 'inset' }) if @still_image.related_items_position == 'inset'
@@ -19,13 +18,11 @@
           :locals => { :still_image => @still_image, |
           :image_file => @image_file })              |
 
-      - cache_with_privacy(@still_image, {:part => 'caption'}) do
-        - if !@still_image.already_at_blank_version?
-          %h4= t 'images.show.caption'
-          %p= @still_image.description.html_safe
+      - if !@still_image.already_at_blank_version?
+        %h4= t 'images.show.caption'
+        %p= @still_image.description.html_safe
 
-      - cache_with_privacy(@still_image, {:part => 'details_second'}) do
-        = pending_review(@still_image)
+      = pending_review(@still_image)
 
       = render(:partial => "topics/extended_fields", :locals => { :item => @still_image, :embedded => true })
       %div{:style => "clear:both;"}

--- a/app/views/search/rss.xml.haml
+++ b/app/views/search/rss.xml.haml
@@ -1,70 +1,69 @@
-- cache(@cache_key_hash) do
-  - blather = params[:page] && params[:page].to_i > 1 ? t('search.rss.next') : t('search.rss.latest')
-  - @title = title_setup_first_part(SITE_NAME + " - #{blather} #{t('search.rss.x_results_in', :amount => @number_per_page)} ") + last_part_of_title_for_rss_if_refinement_of
-  = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') { |xml|                                                                                                |
-    xml.rss(:version => '2.0',                                                                                                                              |
-            "xmlns:media" => "http://search.yahoo.com/mrss",                                                                                                |
-            "xmlns:opensearch" => "http://a9.com/-/spec/opensearch/1.1/",                                                                                   |
-            "xmlns:atom" => "http://www.w3.org/2005/Atom") {                                                                                                |
-      xml.channel {                                                                                                                                         |
-        will_paginate_atom(@results, xml)                                                                                                                   |
-        xml.title @title                                                                                                                                    |
-        xml.link (request.protocol + request.host + request.original_url)                                                                                    |
-        xml.description t('search.rss.showing_x-y_of_z',                                                                                                    |
-                          :start => @start,                                                                                                                 |
-                          :end => @end_record,                                                                                                              |
-                          :total => @result_sets[@current_class].size)                                                                                      |
-        xml.language 'en-nz'                                                                                                                                |
-        xml.send("opensearch:totalResults", @result_sets[@current_class].size)                                                                              |
-        xml.send("opensearch:startIndex", ((@current_page - 1) * @number_per_page))                                                                         |
-        xml.send("opensearch:itemsPerPage", @number_per_page)                                                                                               |
-        xml.send("opensearch:Query", :role => "request", :searchTerms => @search_terms) unless @search_terms.blank?                                         |
-        for result in @results                                                                                                                              |
-          xml.item {                                                                                                                                        |
-            xml.title {                                                                                                                                     |
-              xml.cdata result[:title]                                                                                                                      |
-            }                                                                                                                                               |
-            short_summary = strip_tags(result[:short_summary].to_s)                                                                                         |
-            # this enables things like cooliris (http://cooliris.com)                                                                                       |
-            # note that it goes before short summary may have the thumbnail added                                                                           |
-            # so as not to include it in media:description                                                                                                  |
-            # also handles podcasts with inclusion of backwards compatible enclosure tag                                                                    |
-            unless result[:media_content].blank?                                                                                                            |
-              xml.send("media:content", :url => result[:media_content][:src], :type => result[:media_content][:content_type])                               |
-              xml.send("media:description") {                                                                                                               |
-                xml.cdata short_summary                                                                                                                     |
-              }                                                                                                                                             |
-              xml.enclosure(:url => result[:media_content][:src], :type => result[:media_content][:content_type], :length => result[:media_content][:size]) |
-            end                                                                                                                                             |
-            unless result[:thumbnail].blank?                                                                                                                |
-              thumbnail_html = render(:partial => 'thumb_image_tag',                                                                                        |
-                                      :locals => { :thumbnail => result[:thumbnail],                                                                        |
-                                        :title => result[:title] })                                                                                         |
-              short_summary = thumbnail_html + short_summary                                                                                                |
-            end                                                                                                                                             |
-            xml.send("media:thumbnail", :url => result[:medium][:src]) unless result[:medium].blank?                                                        |
-            # include thumbnails of related images for topics                                                                                               |
-            # and totals of related items for everything                                                                                                    |
-            if result[:related]                                                                                                                             |
-              related = result[:related]                                                                                                                    |
-              related_string = "<p>#{t('search.rss.related')} "                                                                                             |
-              totals_array = related[:counts].keys.collect { |key| zoom_class_humanize_after(related[:counts][key], key.to_s.classify) }                    |
-              related_string += totals_array.to_sentence + '</p>'                                                                                           |
-              if !related[:still_images].blank?                                                                                                             |
-                related_string += "<p>"                                                                                                                     |
-                related_string += topic_related_thumbs_from(related[:still_images])                                                                         |
-                related_string += "</p>"                                                                                                                    |
-              end                                                                                                                                           |
-              short_summary = short_summary + related_string                                                                                                |
-            end                                                                                                                                             |
-            xml.description {                                                                                                                               |
-              xml.cdata short_summary                                                                                                                       |
-            }                                                                                                                                               |
-            xml.pubDate result[:date]                                                                                                                       |
-            xml.link result[:url]                                                                                                                           |
-            xml.guid result[:url]                                                                                                                           |
-          }                                                                                                                                                 |
-        end                                                                                                                                                 |
-      }                                                                                                                                                     |
-    }                                                                                                                                                       |
-    }.to_xml                                                                                                                                                |
+- blather = params[:page] && params[:page].to_i > 1 ? t('search.rss.next') : t('search.rss.latest')
+- @title = title_setup_first_part(SITE_NAME + " - #{blather} #{t('search.rss.x_results_in', :amount => @number_per_page)} ") + last_part_of_title_for_rss_if_refinement_of
+= Nokogiri::XML::Builder.new(:encoding => 'UTF-8') { |xml|                                                                                                |
+  xml.rss(:version => '2.0',                                                                                                                              |
+          "xmlns:media" => "http://search.yahoo.com/mrss",                                                                                                |
+          "xmlns:opensearch" => "http://a9.com/-/spec/opensearch/1.1/",                                                                                   |
+          "xmlns:atom" => "http://www.w3.org/2005/Atom") {                                                                                                |
+    xml.channel {                                                                                                                                         |
+      will_paginate_atom(@results, xml)                                                                                                                   |
+      xml.title @title                                                                                                                                    |
+      xml.link (request.protocol + request.host + request.original_url)                                                                                    |
+      xml.description t('search.rss.showing_x-y_of_z',                                                                                                    |
+                        :start => @start,                                                                                                                 |
+                        :end => @end_record,                                                                                                              |
+                        :total => @result_sets[@current_class].size)                                                                                      |
+      xml.language 'en-nz'                                                                                                                                |
+      xml.send("opensearch:totalResults", @result_sets[@current_class].size)                                                                              |
+      xml.send("opensearch:startIndex", ((@current_page - 1) * @number_per_page))                                                                         |
+      xml.send("opensearch:itemsPerPage", @number_per_page)                                                                                               |
+      xml.send("opensearch:Query", :role => "request", :searchTerms => @search_terms) unless @search_terms.blank?                                         |
+      for result in @results                                                                                                                              |
+        xml.item {                                                                                                                                        |
+          xml.title {                                                                                                                                     |
+            xml.cdata result[:title]                                                                                                                      |
+          }                                                                                                                                               |
+          short_summary = strip_tags(result[:short_summary].to_s)                                                                                         |
+          # this enables things like cooliris (http://cooliris.com)                                                                                       |
+          # note that it goes before short summary may have the thumbnail added                                                                           |
+          # so as not to include it in media:description                                                                                                  |
+          # also handles podcasts with inclusion of backwards compatible enclosure tag                                                                    |
+          unless result[:media_content].blank?                                                                                                            |
+            xml.send("media:content", :url => result[:media_content][:src], :type => result[:media_content][:content_type])                               |
+            xml.send("media:description") {                                                                                                               |
+              xml.cdata short_summary                                                                                                                     |
+            }                                                                                                                                             |
+            xml.enclosure(:url => result[:media_content][:src], :type => result[:media_content][:content_type], :length => result[:media_content][:size]) |
+          end                                                                                                                                             |
+          unless result[:thumbnail].blank?                                                                                                                |
+            thumbnail_html = render(:partial => 'thumb_image_tag',                                                                                        |
+                                    :locals => { :thumbnail => result[:thumbnail],                                                                        |
+                                      :title => result[:title] })                                                                                         |
+            short_summary = thumbnail_html + short_summary                                                                                                |
+          end                                                                                                                                             |
+          xml.send("media:thumbnail", :url => result[:medium][:src]) unless result[:medium].blank?                                                        |
+          # include thumbnails of related images for topics                                                                                               |
+          # and totals of related items for everything                                                                                                    |
+          if result[:related]                                                                                                                             |
+            related = result[:related]                                                                                                                    |
+            related_string = "<p>#{t('search.rss.related')} "                                                                                             |
+            totals_array = related[:counts].keys.collect { |key| zoom_class_humanize_after(related[:counts][key], key.to_s.classify) }                    |
+            related_string += totals_array.to_sentence + '</p>'                                                                                           |
+            if !related[:still_images].blank?                                                                                                             |
+              related_string += "<p>"                                                                                                                     |
+              related_string += topic_related_thumbs_from(related[:still_images])                                                                         |
+              related_string += "</p>"                                                                                                                    |
+            end                                                                                                                                           |
+            short_summary = short_summary + related_string                                                                                                |
+          end                                                                                                                                             |
+          xml.description {                                                                                                                               |
+            xml.cdata short_summary                                                                                                                       |
+          }                                                                                                                                               |
+          xml.pubDate result[:date]                                                                                                                       |
+          xml.link result[:url]                                                                                                                           |
+          xml.guid result[:url]                                                                                                                           |
+        }                                                                                                                                                 |
+      end                                                                                                                                                 |
+    }                                                                                                                                                     |
+  }                                                                                                                                                       |
+  }.to_xml                                                                                                                                                |

--- a/app/views/topics/_actions_menu.html.haml
+++ b/app/views/topics/_actions_menu.html.haml
@@ -6,5 +6,5 @@
     %li= link_to_edit_for(item)
     %li= link_to_history_for(item)
     - if logged_in? and @at_least_a_moderator
-      %li= link_to t('topics.actions_menu.delete'), { action: :destroy, id: @cache_id }, method: :delete, confirm: t('topics.actions_menu.delete_confirm'), tabindex: '1'
+      %li= link_to t('topics.actions_menu.delete'), { action: :destroy, id: item.id }, method: :delete, confirm: t('topics.actions_menu.delete_confirm'), tabindex: '1'
     = render :partial => 'topics/privacy_chooser', :locals => { :item => item } if @show_privacy_chooser

--- a/app/views/topics/_contributors.html.haml
+++ b/app/views/topics/_contributors.html.haml
@@ -2,10 +2,9 @@
 %div{:class => "secondary-content-section-wrapper"}
   %div{:class => "secondary-content-section#{additional_classes}", :id => "content-tools"}
     .secondary-content-section-content
-      - cache_with_privacy(item, {:part => 'contributor'}) do
-        - if item.created_at < item.updated_at
-          = stylish_link_to_contributions_of(@last_contributor, 'Topic', :additional_classes => ['last_edited_link'], :additional_html => add_to_stylish_display_with("#{t('topics.contributors.last_to_edit')} #{h(item.title)}") + add_to_stylish_display_with("#{t('topics.contributors.created_or_updated_on')} #{item.updated_at.to_s(:natural_short)}").html_safe).html_safe
-        = stylish_link_to_contributions_of(@creator, 'Topic', :additional_classes => ['created_link'], :additional_html => add_to_stylish_display_with("#{t('topics.contributors.created')} #{h(item.title)}") + add_to_stylish_display_with("#{t('topics.contributors.created_or_updated_on')} #{item.created_at.to_s(:natural_short)}")) |
+      - if item.created_at < item.updated_at
+        = stylish_link_to_contributions_of(@last_contributor, 'Topic', :additional_classes => ['last_edited_link'], :additional_html => add_to_stylish_display_with("#{t('topics.contributors.last_to_edit')} #{h(item.title)}") + add_to_stylish_display_with("#{t('topics.contributors.created_or_updated_on')} #{item.updated_at.to_s(:natural_short)}").html_safe).html_safe
+      = stylish_link_to_contributions_of(@creator, 'Topic', :additional_classes => ['created_link'], :additional_html => add_to_stylish_display_with("#{t('topics.contributors.created')} #{h(item.title)}") + add_to_stylish_display_with("#{t('topics.contributors.created_or_updated_on')} #{item.created_at.to_s(:natural_short)}")) |
       .clear
       %div{:style => "clear:both;"}
     .secondary-content-section-footer-wrapper

--- a/app/views/topics/_extended_fields.html.haml
+++ b/app/views/topics/_extended_fields.html.haml
@@ -1,17 +1,15 @@
 - embedded = nil unless defined?(embedded)
-- cache_key = embedded ? "secondary_content_extended_fields_embedded" : "secondary_content_extended_fields"
-- cache_with_privacy(item, {:part => cache_key}) do
-  - extended_fields_html = display_xml_attributes(item, :embedded_only => embedded)
-  - if !extended_fields_html.blank?
-    = '<div id="embedded_extended_field_data">'.html_safe if embedded
-    %div{:class => "secondary-content-section-wrapper"}
-      %div{:class => "secondary-content-section", :id => "extended-fields"}
-        .secondary-content-section-content
-          #detail-extended
-            %h4#detail-extended-heading= h(item.title)
-            %br/
-            = extended_fields_html
-          %div{:style => "clear:both;"}
-        .secondary-content-section-footer-wrapper
-          .secondary-content-section-footer &nbsp;
-    = '</div>'.html_safe if embedded
+- extended_fields_html = display_xml_attributes(item, :embedded_only => embedded)
+- if !extended_fields_html.blank?
+  = '<div id="embedded_extended_field_data">'.html_safe if embedded
+  %div{:class => "secondary-content-section-wrapper"}
+    %div{:class => "secondary-content-section", :id => "extended-fields"}
+      .secondary-content-section-content
+        #detail-extended
+          %h4#detail-extended-heading= h(item.title)
+          %br/
+          = extended_fields_html
+        %div{:style => "clear:both;"}
+      .secondary-content-section-footer-wrapper
+        .secondary-content-section-footer &nbsp;
+  = '</div>'.html_safe if embedded

--- a/app/views/topics/_license.html.haml
+++ b/app/views/topics/_license.html.haml
@@ -1,9 +1,8 @@
-- cache_with_privacy(item, {:part => "secondary_content_license_metadata"}) do
-  - unless item.license_metadata.nil?
-    %div{:class => "secondary-content-section-wrapper"}
-      %div{:class => "secondary-content-section", :id => "license-box"}
-        .secondary-content-section-content
-          .license= item.license_metadata.html_safe
-          %div{:style => "clear:both;"}
-        .secondary-content-section-footer-wrapper
-          .secondary-content-section-footer &nbsp;
+- unless item.license_metadata.nil?
+  %div{:class => "secondary-content-section-wrapper"}
+    %div{:class => "secondary-content-section", :id => "license-box"}
+      .secondary-content-section-content
+        .license= item.license_metadata.html_safe
+        %div{:style => "clear:both;"}
+      .secondary-content-section-footer-wrapper
+        .secondary-content-section-footer &nbsp;

--- a/app/views/topics/_privacy_chooser.html.haml
+++ b/app/views/topics/_privacy_chooser.html.haml
@@ -1,7 +1,6 @@
 - location_hash = { :controller => params[:controller], :action => ((params[:controller] == 'index_page') ? 'index' : 'show'), :id => params[:id] }
-- cache_with_privacy(item, {:part => 'privacy_chooser'}) do
-  - if item.respond_to?(:private?)
-    - if item.private?
-      %li= link_to t('topics.privacy_chooser.public_version'), location_hash.merge({:private=>"false"}), :tabindex => '1'
-    - elsif !item.private? && item.has_private_version?
-      %li= link_to t('topics.privacy_chooser.private_version'), location_hash.merge({:private=>"true", :only_path => false}), :tabindex => '1'
+- if item.respond_to?(:private?)
+  - if item.private?
+    %li= link_to t('topics.privacy_chooser.public_version'), location_hash.merge({:private=>"false"}), :tabindex => '1'
+  - elsif !item.private? && item.has_private_version?
+    %li= link_to t('topics.privacy_chooser.private_version'), location_hash.merge({:private=>"true", :only_path => false}), :tabindex => '1'

--- a/app/views/topics/_related_items.html.haml
+++ b/app/views/topics/_related_items.html.haml
@@ -3,13 +3,12 @@
 - topics_only ||= false
 - position ||= ''
 
-- @total_item_counts = related_items_count_for_current_item
+- @total_item_counts = related_items_count_for_current_item(item)
 - if @total_item_counts > 0
   - options = { :item_classes => (topics_only ? ['Topic'] : nil), :with_counts => true, :start_record => 0,
               :end_record => [SystemSetting.number_of_related_images_to_display, SystemSetting.number_of_related_things_to_display_per_type].sort.last }
   - @public_items, @public_item_counts = public_related_items_for(item, options)
   - @private_items, @private_item_counts = private_related_items_for(item, options)
-
 
 
 %div{ :id => "related_items", :class => related_items_class_from(position, related_items.count), :style => related_items_styles_from(position, related_items.count) }

--- a/app/views/topics/_related_items_tools.html.haml
+++ b/app/views/topics/_related_items_tools.html.haml
@@ -2,15 +2,14 @@
   #related-items-tools
     %ul
       - zoom_class = zoom_class_from_controller(params[:controller])
-      - cache({ :related => 'related-tools-create-or-link-or-remove', :id => @cache_id }) do
-        - if zoom_class == 'Topic'
-          = header_add_links(:link_text => t('topics.related_items.create'), :class => 'first', |
-            :related_item_private => (params[:private] && params[:private] == 'true'),          |
-            :relate_to_item => item, :relate_to_type => zoom_class).html_safe                   |
-        - else
-          %li.first
-            = link_to(t('topics.related_items.create'), :controller => 'topics', :action => :new, :related_item_private => (params[:private] && params[:private] == 'true'), :relate_to_item => item, :relate_to_type => zoom_class)
-        
+      - if zoom_class == 'Topic'
+        = header_add_links(:link_text => t('topics.related_items.create'), :class => 'first', |
+          :related_item_private => (params[:private] && params[:private] == 'true'),          |
+          :relate_to_item => item, :relate_to_type => zoom_class).html_safe                   |
+      - else
+        %li.first
+          = link_to(t('topics.related_items.create'), :controller => 'topics', :action => :new, :related_item_private => (params[:private] && params[:private] == 'true'), :relate_to_item => item, :relate_to_type => zoom_class)
+
         = link_to_related_item_function(:link_text => t('topics.related_items.link_existing'), :function => 'add', :relate_to_item => item, :relate_to_type => zoom_class)
 
         = link_to_related_item_function(:link_text => t('topics.related_items.remove'), :function => 'remove', :relate_to_item => item, :relate_to_type => zoom_class)

--- a/app/views/topics/_tags_div.html.haml
+++ b/app/views/topics/_tags_div.html.haml
@@ -1,10 +1,9 @@
 %div{:class => "secondary-content-section-wrapper"}
   %div{:class => "secondary-content-section", :id => "tags-box"}
     .secondary-content-section-content
-      = cache_with_privacy(item, {:part => "secondary_content_tags"}) do
-        %h2= t 'topics.tags.title'
-        #tags_list
-          = tags_for(item).html_safe
+      %h2= t 'topics.tags.title'
+      #tags_list
+        = tags_for(item).html_safe
       - if permitted_to_edit_current_item? && params[:action] != 'preview'
         - item_key = zoom_class_from_controller(params[:controller]).underscore
         #add_tag_button{:style => "display:none"}

--- a/app/views/video/show.html.haml
+++ b/app/views/video/show.html.haml
@@ -6,8 +6,7 @@
   #main-content-wrapper
     #main-content-container
       %a{:name => "main-content"}
-      - cache_with_privacy(@video, {:part => 'details_first'}) do
-        %h2= h(@video.title)
+      %h2= h(@video.title)
 
       = extras_after_title_headline
 
@@ -15,9 +14,8 @@
 
       = render(:partial => "details", :locals => { :item => @video }) if show_attached_files_for?(@video)
 
-      - cache_with_privacy(@video, {:part => 'details_second'}) do
-        %p= @video.description.html_safe
-        = pending_review(@video)
+      %p= @video.description.html_safe
+      = pending_review(@video)
 
       = render(:partial => "topics/extended_fields", :locals => { :item => @video, :embedded => true })
       %div{:style => "clear:both;"}

--- a/app/views/web_links/show.html.haml
+++ b/app/views/web_links/show.html.haml
@@ -6,17 +6,15 @@
   #main-content-wrapper
     #main-content-container
       %a{:name => "main-content"}
-      - cache_with_privacy(@web_link, {:part => 'details_first'}) do
-        %h2= link_to h(@web_link.title), url_for(@web_link.url)
+      %h2= link_to h(@web_link.title), url_for(@web_link.url)
 
       = extras_after_title_headline
 
       = render(:partial => "topics/related_items", :locals => { :item => @web_link, :related_items => @related_item_topics, :position => 'inset' }) if @web_link.related_items_position == 'inset'
 
-      - cache_with_privacy(@web_link, {:part => 'details_second'}) do
-        = render(:partial => "details", :locals => { :item => @web_link })
-        %p= @web_link.description.html_safe
-        = pending_review(@web_link)
+      = render(:partial => "details", :locals => { :item => @web_link })
+      %p= @web_link.description.html_safe
+      = pending_review(@web_link)
 
       = render(:partial => "topics/extended_fields", :locals => { :item => @web_link, :embedded => true })
       %div{:style => "clear:both;"}


### PR DESCRIPTION
Remove the smattering of caching left in the views, and clean up left over cruft from the controllers. Caching was broken and preventing content from being updated.

Changes mostly removing `cache_with_privacy` calls with some tweaking of view-partials/controllers to remove `@cache_id` variable and unneeded helpers.