### PR TITLE
Allow privileged users (e.g. admins) to edit comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -110,11 +110,6 @@ class CommentsController < ApplicationController
       # make sure that we wipe comments cache for thing we are commenting on
       commented_item = @comment.commentable
 
-      # switched to async backgroundrb worker for search record set up
-      update_search_record_for(@comment)
-
-      update_search_record_for(commented_item)
-
       flash[:notice] = t('comments_controller.update.updated')
       redirect_to url_for(:controller => zoom_class_controller(commented_item.class.name),
                           :action => 'show',

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -539,6 +539,7 @@ module ApplicationHelper
       html += link_to(t('application_helper.link_to_cancel.cancel'), url_for(session[:return_to]), :tabindex => '1')
     end
     html += "</div>"
+    html.html_safe
   end
 
   def link_to_item(item)
@@ -1261,10 +1262,10 @@ module ApplicationHelper
                                              :controller => 'comments',
                                              :action => :edit,
                                              :id => comment) + "</li>\n"
-          comment_string += "<li>" + link_to(t('application_helper.show_comments_for.history'),
-                                             :controller => 'comments',
-                                             :action => :history,
-                                             :id => comment) + "</li>\n"
+          # comment_string += "<li>" + link_to(t('application_helper.show_comments_for.history'),
+          #                                    :controller => 'comments',
+          #                                    :action => :history,
+          #                                    :id => comment) + "</li>\n"
           comment_string += "<li>" + link_to(t('application_helper.show_comments_for.delete'),
                                              {:action => :destroy,
                                                :controller => 'comments',

--- a/app/views/comments/edit.html.haml
+++ b/app/views/comments/edit.html.haml
@@ -1,10 +1,8 @@
 - @title = t('comments.edit.title')
 %h2= h(@title)
-- form_for :comment,
-- :url => { :action => 'update',
-- :id => @comment },
-- :html => { :multipart => true } do |form|
+= form_for :comment, method: :put, url: { action: 'update', id: @comment } do |form|
   = render :partial => 'form', :object => form
-  .wrap= submit_tag t('comments.edit.button'), {:class => "save-button", :tabindex => '1'}
+  .wrap
+    = submit_tag t('comments.edit.button'), {:class => "save-button", :tabindex => '1'}
 = link_to_cancel
 

--- a/app/views/comments/new.html.haml
+++ b/app/views/comments/new.html.haml
@@ -12,7 +12,7 @@
   .wrap
     = submit_tag t('comments.new.button'), {:class => "save-button", :tabindex => '1'}
 
-= link_to_cancel.html_safe
+= link_to_cancel
 
 - if @parent_comment
   #comment_in_response_to

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,9 +38,10 @@ load_yaml(file: 'roles.yml',
           model: Role,
           unique_attrs: [:id])
 
-load_yaml(file: 'users.yml',
-          model: User,
-          unique_attrs: [:email])
+load_yaml(file: 'users.yml', model: User, unique_attrs: [:email]) do |user|
+  # activate admin after create
+  user.activate if user.login == 'admin'
+end
 
 load_yaml(file: 'roles_users.yml',
           model: RolesUser,


### PR DESCRIPTION
* Remove unnecessary calls from CommentsController#update to old search system.
* Fix bugs preventing Admins from editing existing comments
* Hide history link from comments as it is not a needed feature anymore

Other improvements

* Activate admin user created by seeds