### PR TITLE
Security improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ before_script:
   - cp config/database.travis.yml config/database.yml
   - psql -c 'create database travis_ci_test' -U postgres
   - RAILS_ENV=test bundle exec rake db:schema:load
+  - bundle exec bundle-audit update
   - npm install
 script:
   - bundle exec rspec spec -f p
   - bundle exec rubocop
+  - bundle exec bundle-audit check
   - ./node_modules/.bin/grunt

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 ruby '2.1.2'
 
-gem "rails", "3.2.19"
+gem "rails", "3.2.21"
 gem 'unicorn'
 
 gem 'tinymce-rails', '~> 4.1.4'
@@ -15,7 +15,7 @@ gem 'rails_12factor', group: :production
 
 gem 'jquery-rails', '~> 3.1.1'
 gem 'haml'
-gem 'acts_as_licensed', github: 'kete/acts_as_licensed', branch: 'rails3-gem'
+gem 'acts_as_licensed', git: 'https://github.com/kete/acts_as_licensed.git', branch: 'rails3-gem'
 # gem "sql-logging"
 
 gem "figaro", "~> 0.7.0"
@@ -23,7 +23,7 @@ gem "pg_search", "~> 0.7.2"
 
 # RABID: the official version of acts_as_versioned seems to be abandoned but
 # 		 this fork claims to have rails 3 support
-gem 'acts_as_versioned', github: "jwhitehorn/acts_as_versioned"
+gem 'acts_as_versioned', git: "https://github.com/jwhitehorn/acts_as_versioned.git", ref: "44dfe632ba8c97c786cbc172a2da18a41b17f668"
 
 # RABID: the old plugin version of acts-as-taggable-on was 1.0.0
 gem 'acts-as-taggable-on', '~> 3.3.0'
@@ -43,8 +43,7 @@ gem 'acts-as-taggable-on', '~> 3.3.0'
 # * OverrideAttachmentFuMethods
 # * ResizeAsJpegWhenNecessary
 #
-gem 'pothoven-attachment_fu', github: 'kete/attachment_fu'
-
+gem 'pothoven-attachment_fu', git: 'https://github.com/kete/attachment_fu.git'
 
 gem 'validate_url'
 
@@ -52,7 +51,7 @@ gem 'validate_url'
 #       external_search_sources plugin.
 #       It'll probably be possible to pull these function into external_search_sources
 #       allowing us to use the stock feedzirra gem.
-gem 'kete-feedzirra', github: 'kete/feedzirra'
+gem 'kete-feedzirra', git: 'https://github.com/kete/feedzirra'
 
 # https://github.com/swanandp/acts_as_list
 gem 'acts_as_list', '~> 0.3.0'
@@ -95,7 +94,7 @@ gem 'rmagick', "2.13.3", require: 'RMagick'
 gem 'oai', '~> 0.3.1'
 
 gem 'packet'
-gem 'RedCloth'
+gem 'redcarpet', '~> 3.2.3'
 gem 'hpricot'
 
 ##gem 'tiny_mce'
@@ -151,7 +150,7 @@ gem 'active_scaffold', '~> 3.3.3'
 
 
 #gem "acts_as_licensed", "#.#.#", :git => "git://github.com/shuber/sortable.git" # 2008-07-10
-gem "acts_as_soft_deletable", :git => "git://github.com/says/acts_as_soft_deletable.git" # 2009-02-16
+gem "acts_as_soft_deletable", :git => "https://github.com/says/acts_as_soft_deletable.git" # 2009-02-16
 ## gem 'acts_as_zoom'
 #gem 'auto_complete',                '0.0.1' # >> 2008-10-23
 #gem 'backgroundrb-rails3',          '1.1.0' # >> 2008-10-15, replaces 'backgroundrb'
@@ -186,7 +185,7 @@ gem 'validates_xml',                '1.0.3' # >> 2007-06-06
 # The authorization gem has not been updated in years. We took this fork from a
 # fork that had some fixes applied to make it work with Ruby 2.0. We are using
 # our own fork to be sure that the repo will not be deleted in future.
-gem 'authorization', github: 'kete/rails-authorization-plugin'
+gem 'authorization', git: 'https://github.com/kete/rails-authorization-plugin'
 
 # ######
 # Assets
@@ -221,6 +220,7 @@ group :development, :test do
   gem 'awesome_print'
   gem "factory_girl_rails", "~> 4.5.0"
   gem 'rubocop', '~> 0.31.0', require: false
+  gem 'bundler-audit', '~> 0.3.1', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,27 @@
 GIT
-  remote: git://github.com/jwhitehorn/acts_as_versioned.git
+  remote: https://github.com/jwhitehorn/acts_as_versioned.git
   revision: 44dfe632ba8c97c786cbc172a2da18a41b17f668
+  ref: 44dfe632ba8c97c786cbc172a2da18a41b17f668
   specs:
     acts_as_versioned (3.2.1)
       activerecord
 
 GIT
-  remote: git://github.com/kete/acts_as_licensed.git
-  revision: 51404e95591af17236bb96f072cb2d7b5582af5f
+  remote: https://github.com/kete/acts_as_licensed.git
+  revision: 4eabf1d97c5c8206e2ca239cdccf3b81b1072792
   branch: rails3-gem
   specs:
     acts_as_licensed (0.0.1)
       railties (>= 3.0.0)
 
 GIT
-  remote: git://github.com/kete/attachment_fu.git
+  remote: https://github.com/kete/attachment_fu.git
   revision: 8b6c7beda9e0d9528245f26648e66a243d95216d
   specs:
     pothoven-attachment_fu (3.2.13)
 
 GIT
-  remote: git://github.com/kete/feedzirra.git
+  remote: https://github.com/kete/feedzirra
   revision: c38c7ab43d75de4f073f6f8f34531a785054f363
   specs:
     kete-feedzirra (0.0.20.1)
@@ -32,13 +33,13 @@ GIT
       sax-machine (>= 0.0.12)
 
 GIT
-  remote: git://github.com/kete/rails-authorization-plugin.git
+  remote: https://github.com/kete/rails-authorization-plugin
   revision: ab7259d323e35d16321121566d71689648c2bf2a
   specs:
     authorization (1.0.12)
 
 GIT
-  remote: git://github.com/says/acts_as_soft_deletable.git
+  remote: https://github.com/says/acts_as_soft_deletable.git
   revision: 17b5ca72307be459c70cad6e7f9990be055e8d3a
   specs:
     acts_as_soft_deletable (0.0.2)
@@ -47,13 +48,12 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    RedCloth (4.2.9)
-    actionmailer (3.2.19)
-      actionpack (= 3.2.19)
+    actionmailer (3.2.21)
+      actionpack (= 3.2.21)
       mail (~> 2.5.4)
-    actionpack (3.2.19)
-      activemodel (= 3.2.19)
-      activesupport (= 3.2.19)
+    actionpack (3.2.21)
+      activemodel (= 3.2.21)
+      activesupport (= 3.2.21)
       builder (~> 3.0.0)
       erubis (~> 2.7.0)
       journey (~> 1.0.4)
@@ -63,18 +63,18 @@ GEM
       sprockets (~> 2.2.1)
     active_scaffold (3.3.3)
       rails (~> 3.2.0)
-    activemodel (3.2.19)
-      activesupport (= 3.2.19)
+    activemodel (3.2.21)
+      activesupport (= 3.2.21)
       builder (~> 3.0.0)
-    activerecord (3.2.19)
-      activemodel (= 3.2.19)
-      activesupport (= 3.2.19)
+    activerecord (3.2.21)
+      activemodel (= 3.2.21)
+      activesupport (= 3.2.21)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
-    activeresource (3.2.19)
-      activemodel (= 3.2.19)
-      activesupport (= 3.2.19)
-    activesupport (3.2.19)
+    activeresource (3.2.21)
+      activemodel (= 3.2.21)
+      activesupport (= 3.2.21)
+    activesupport (3.2.21)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     acts-as-taggable-on (3.3.0)
@@ -96,6 +96,9 @@ GEM
       packet (>= 0.1.15)
       rails (>= 3.0.0)
     builder (3.0.4)
+    bundler-audit (0.3.1)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     byebug (2.3.1)
       columnize (~> 0.3.6)
       debugger-linecache (~> 1.2.0)
@@ -140,7 +143,7 @@ GEM
       sass (~> 3.1)
     compass-rails (1.0.3)
       compass (>= 0.12.2, < 0.14)
-    curb (0.8.5)
+    curb (0.8.8)
     database_cleaner (1.4.1)
     debugger (1.6.2)
       columnize (>= 0.3.1)
@@ -177,16 +180,16 @@ GEM
     htmlentities (4.3.1)
     http_url_validation_improved (1.3.1)
       addressable
-    i18n (0.6.11)
+    i18n (0.7.0)
     journey (1.0.4)
     jquery-rails (3.1.1)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.1)
+    json (1.8.3)
     kgio (2.9.2)
     libxml-ruby (2.7.0)
-    loofah (1.2.1)
-      nokogiri (>= 1.4.4)
+    loofah (2.0.2)
+      nokogiri (>= 1.5.9)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -194,7 +197,7 @@ GEM
     mime-types (1.25.1)
     mini_exiftool (1.7.0)
     mini_portile (0.6.2)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     multipart-post (1.2.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -243,14 +246,14 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     railroady (1.1.1)
-    rails (3.2.19)
-      actionmailer (= 3.2.19)
-      actionpack (= 3.2.19)
-      activerecord (= 3.2.19)
-      activeresource (= 3.2.19)
-      activesupport (= 3.2.19)
+    rails (3.2.21)
+      actionmailer (= 3.2.21)
+      actionpack (= 3.2.21)
+      activerecord (= 3.2.21)
+      activeresource (= 3.2.21)
+      activesupport (= 3.2.21)
       bundler (~> 1.0)
-      railties (= 3.2.19)
+      railties (= 3.2.21)
     rails-erd (1.1.0)
       activerecord (>= 3.0)
       activesupport (>= 3.0)
@@ -261,18 +264,19 @@ GEM
       rails_stdout_logging
     rails_serve_static_assets (0.0.2)
     rails_stdout_logging (0.0.3)
-    railties (3.2.19)
-      actionpack (= 3.2.19)
-      activesupport (= 3.2.19)
+    railties (3.2.21)
+      actionpack (= 3.2.21)
+      activesupport (= 3.2.21)
       rack-ssl (~> 1.3.2)
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     rainbow (2.0.0)
     raindrops (0.13.0)
-    rake (10.3.2)
+    rake (10.4.2)
     rdoc (3.12.2)
       json (~> 1.4)
+    redcarpet (3.2.3)
     rmagick (2.13.3)
     routing-filter (0.3.1)
       actionpack
@@ -306,15 +310,14 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    sax-machine (0.2.1)
-      nokogiri (~> 1.6.0)
+    sax-machine (1.3.2)
     selenium-webdriver (2.45.0)
       childprocess (~> 0.5)
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
     slop (3.4.6)
-    sprockets (2.2.2)
+    sprockets (2.2.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -330,7 +333,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.41)
+    tzinfo (0.3.44)
     uglifier (2.1.2)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
@@ -356,7 +359,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  RedCloth
   active_scaffold (~> 3.3.3)
   acts-as-taggable-on (~> 3.3.0)
   acts_as_configurable (= 0.0.8)
@@ -369,6 +371,7 @@ DEPENDENCIES
   awesome_nested_set (~> 2.1.6)
   awesome_print
   backgroundrb-rails3 (~> 1.1.6)
+  bundler-audit (~> 0.3.1)
   byebug
   capistrano (~> 3.2.1)
   capistrano-bundler (~> 1.1.3)
@@ -405,10 +408,11 @@ DEPENDENCIES
   pry-rails
   quiet_assets
   railroady
-  rails (= 3.2.19)
+  rails (= 3.2.21)
   rails-erd
   rails_12factor
   rake
+  redcarpet (~> 3.2.3)
   rmagick (= 2.13.3)
   routing-filter (~> 0.3.1)
   rspec-rails (~> 3.0.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,5 @@
 # Controls needed for Gravatar support throughout the site
 require 'avatar/view/action_view_support'
-require 'redcloth'
 
 # Methods added to this helper will be available to all templates in the application.
 module ApplicationHelper
@@ -1157,13 +1156,14 @@ module ApplicationHelper
       if ef.ftype == 'textarea'
         value = sanitize(value)
 
-        # format the value to html with RedCloth for things like line breaks
+        # format the value to html for things like line breaks
         # start by replacing carriage returns with newlines
         # gotcha: if you have a \r\n or \n\r, you need to convert both to a
         # single new line before converting all remaining \r to \n (else
         # you get double lines where there should only be a single)
         value = value.gsub(/(\r\n|\n\r|\r)/, "\n")
-        value = RedCloth.new(value).to_html
+        markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+        value = markdown.render(value)
 
         url_regex = '(\w+:\/\/[^ |<]+)'
         email_regex = '([\w._%+-]+@[\w.-]+\.[\w]{2,4})'

--- a/app/views/configure/section.html.haml
+++ b/app/views/configure/section.html.haml
@@ -13,7 +13,7 @@
             = fields_for "setting[]" do |f|
               = f.text_field :value
               .form_example
-                = RedCloth.new(@setting.explanation).to_html.gsub("&#8220;", "\"").gsub("&#8221;", "\"").gsub("&#8217;", "'").gsub("&#8216;", "'").gsub("‘", "'").gsub("’", "'")
+                = Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(@setting.explanation)
         - else
           = fields_for "setting[]" do |f|
             = f.hidden_field :value


### PR DESCRIPTION
Upgrade rails 3 to latest release and put `bundle-audit` in place to
ensure that the team is alerted about gems with known security problems
before they are checked-in.
- Run bundle-audit for each build in CI
- Upgrade to rails 3.2.21
- Replace unmtainained `RedCloth` gem with `redcarpet` (which is maintained)
- Use `https://` URLS to get gems via git repos (instead of less secure `git://` protocol)
