### PR TITLE
Security improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ before_script:
   - cp config/database.travis.yml config/database.yml
   - psql -c 'create database travis_ci_test' -U postgres
   - RAILS_ENV=test bundle exec rake db:schema:load
+  - bundle exec bundle-audit update
   - npm install
 script:
   - bundle exec rspec spec
   - bundle exec rubocop
+  - bundle exec bundle-audit check
   - ./node_modules/.bin/grunt

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'rails_12factor', group: :production
 
 gem 'jquery-rails', '~> 3.1.1'
 gem 'haml'
-gem 'acts_as_licensed', github: 'kete/acts_as_licensed', branch: 'rails3-gem'
+gem 'acts_as_licensed', git: 'https://github.com/kete/acts_as_licensed.git', branch: 'rails3-gem'
 # gem "sql-logging"
 
 gem "figaro", "~> 0.7.0"
@@ -23,7 +23,7 @@ gem "pg_search", "~> 0.7.2"
 
 # RABID: the official version of acts_as_versioned seems to be abandoned but
 # 		 this fork claims to have rails 3 support
-gem 'db_acts_as_versioned', '~> 3.5.0'
+gem 'acts_as_versioned', git: "https://github.com/jwhitehorn/acts_as_versioned.git", ref: "44dfe632ba8c97c786cbc172a2da18a41b17f668"
 
 # RABID: the old plugin version of acts-as-taggable-on was 1.0.0
 gem 'acts-as-taggable-on', '~> 3.3.0'
@@ -43,8 +43,7 @@ gem 'acts-as-taggable-on', '~> 3.3.0'
 # * OverrideAttachmentFuMethods
 # * ResizeAsJpegWhenNecessary
 #
-gem 'pothoven-attachment_fu', github: 'kete/attachment_fu'
-
+gem 'pothoven-attachment_fu', git: 'https://github.com/kete/attachment_fu.git'
 
 gem 'validate_url'
 
@@ -52,7 +51,7 @@ gem 'validate_url'
 #       external_search_sources plugin.
 #       It'll probably be possible to pull these function into external_search_sources
 #       allowing us to use the stock feedzirra gem.
-gem 'kete-feedzirra', github: 'kete/feedzirra'
+gem 'kete-feedzirra', git: 'https://github.com/kete/feedzirra'
 
 # https://github.com/swanandp/acts_as_list
 gem 'acts_as_list', '~> 0.3.0'
@@ -95,7 +94,7 @@ gem 'rmagick', "~> 2.16.0", require: 'RMagick'
 gem 'oai', '~> 0.3.1'
 
 gem 'packet'
-gem 'RedCloth'
+gem 'redcarpet', '~> 3.2.3'
 gem 'hpricot'
 
 ##gem 'tiny_mce'
@@ -151,7 +150,7 @@ gem 'active_scaffold', '~> 3.3.3'
 
 
 #gem "acts_as_licensed", "#.#.#", :git => "git://github.com/shuber/sortable.git" # 2008-07-10
-gem "acts_as_soft_deletable", :git => "git://github.com/says/acts_as_soft_deletable.git" # 2009-02-16
+gem "acts_as_soft_deletable", :git => "https://github.com/says/acts_as_soft_deletable.git" # 2009-02-16
 ## gem 'acts_as_zoom'
 #gem 'auto_complete',                '0.0.1' # >> 2008-10-23
 #gem 'backgroundrb-rails3',          '1.1.0' # >> 2008-10-15, replaces 'backgroundrb'
@@ -186,7 +185,7 @@ gem 'validates_xml',                '1.0.3' # >> 2007-06-06
 # The authorization gem has not been updated in years. We took this fork from a
 # fork that had some fixes applied to make it work with Ruby 2.0. We are using
 # our own fork to be sure that the repo will not be deleted in future.
-gem 'authorization', github: 'kete/rails-authorization-plugin'
+gem 'authorization', git: 'https://github.com/kete/rails-authorization-plugin'
 
 # ######
 # Assets
@@ -222,6 +221,7 @@ group :development, :test do
   gem "factory_girl_rails", "~> 4.5.0"
   gem 'rubocop', '~> 0.31.0', require: false
   gem 'test-unit', '~> 3.0'
+  gem 'bundler-audit', '~> 0.3.1', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,13 @@
 GIT
-  remote: git://github.com/kete/acts_as_licensed.git
+  remote: https://github.com/jwhitehorn/acts_as_versioned.git
+  revision: 44dfe632ba8c97c786cbc172a2da18a41b17f668
+  ref: 44dfe632ba8c97c786cbc172a2da18a41b17f668
+  specs:
+    acts_as_versioned (3.2.1)
+      activerecord
+
+GIT
+  remote: https://github.com/kete/acts_as_licensed.git
   revision: 4eabf1d97c5c8206e2ca239cdccf3b81b1072792
   branch: rails3-gem
   specs:
@@ -7,13 +15,13 @@ GIT
       railties (>= 3.0.0)
 
 GIT
-  remote: git://github.com/kete/attachment_fu.git
+  remote: https://github.com/kete/attachment_fu.git
   revision: 8b6c7beda9e0d9528245f26648e66a243d95216d
   specs:
     pothoven-attachment_fu (3.2.13)
 
 GIT
-  remote: git://github.com/kete/feedzirra.git
+  remote: https://github.com/kete/feedzirra
   revision: c38c7ab43d75de4f073f6f8f34531a785054f363
   specs:
     kete-feedzirra (0.0.20.1)
@@ -25,13 +33,13 @@ GIT
       sax-machine (>= 0.0.12)
 
 GIT
-  remote: git://github.com/kete/rails-authorization-plugin.git
+  remote: https://github.com/kete/rails-authorization-plugin
   revision: ab7259d323e35d16321121566d71689648c2bf2a
   specs:
     authorization (1.0.12)
 
 GIT
-  remote: git://github.com/says/acts_as_soft_deletable.git
+  remote: https://github.com/says/acts_as_soft_deletable.git
   revision: 17b5ca72307be459c70cad6e7f9990be055e8d3a
   specs:
     acts_as_soft_deletable (0.0.2)
@@ -40,7 +48,6 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    RedCloth (4.2.9)
     actionmailer (3.2.22.1)
       actionpack (= 3.2.22.1)
       mail (~> 2.5.4)
@@ -89,6 +96,9 @@ GEM
       packet (>= 0.1.15)
       rails (>= 3.0.0)
     builder (3.0.4)
+    bundler-audit (0.3.1)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     byebug (2.3.1)
       columnize (~> 0.3.6)
       debugger-linecache (~> 1.2.0)
@@ -135,7 +145,6 @@ GEM
       compass (>= 0.12.2, < 0.14)
     curb (0.9.3)
     database_cleaner (1.4.1)
-    db_acts_as_versioned (3.5.0)
     debugger (1.6.2)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
@@ -171,7 +180,7 @@ GEM
     htmlentities (4.3.1)
     http_url_validation_improved (1.3.1)
       addressable
-    i18n (0.7.0)
+    i18n (0.8.4)
     journey (1.0.4)
     jquery-rails (3.1.3)
       railties (>= 3.0, < 5.0)
@@ -231,7 +240,7 @@ GEM
     quiet_assets (1.0.3)
       railties (>= 3.1, < 5.0)
     rack (1.4.7)
-    rack-cache (1.5.1)
+    rack-cache (1.7.0)
       rack (>= 0.4)
     rack-ssl (1.3.4)
       rack
@@ -268,6 +277,7 @@ GEM
     rake (10.5.0)
     rdoc (3.12.2)
       json (~> 1.4)
+    redcarpet (3.2.3)
     rmagick (2.16.0)
     routing-filter (0.3.1)
       actionpack
@@ -354,18 +364,19 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  RedCloth
   active_scaffold (~> 3.3.3)
   acts-as-taggable-on (~> 3.3.0)
   acts_as_configurable (= 0.0.8)
   acts_as_licensed!
   acts_as_list (~> 0.3.0)
   acts_as_soft_deletable!
+  acts_as_versioned!
   authorization!
   avatar
   awesome_nested_set (~> 2.1.6)
   awesome_print
   backgroundrb-rails3 (~> 1.1.6)
+  bundler-audit (~> 0.3.1)
   byebug
   capistrano (~> 3.2.1)
   capistrano-bundler (~> 1.1.3)
@@ -376,7 +387,6 @@ DEPENDENCIES
   coffee-rails (~> 3.2.1)
   compass-rails
   database_cleaner (~> 1.4.1)
-  db_acts_as_versioned (~> 3.5.0)
   debugger
   debugger-xml
   dynamic_form (~> 1.1.4)
@@ -408,6 +418,7 @@ DEPENDENCIES
   rails-erd
   rails_12factor
   rake
+  redcarpet (~> 3.2.3)
   rmagick (~> 2.16.0)
   routing-filter (~> 0.3.1)
   rspec-rails (~> 3.0.0)
@@ -429,4 +440,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,5 @@
 # Controls needed for Gravatar support throughout the site
 require 'avatar/view/action_view_support'
-require 'redcloth'
 
 # Methods added to this helper will be available to all templates in the application.
 module ApplicationHelper
@@ -1158,13 +1157,14 @@ module ApplicationHelper
       if ef.ftype == 'textarea'
         value = sanitize(value)
 
-        # format the value to html with RedCloth for things like line breaks
+        # format the value to html for things like line breaks
         # start by replacing carriage returns with newlines
         # gotcha: if you have a \r\n or \n\r, you need to convert both to a
         # single new line before converting all remaining \r to \n (else
         # you get double lines where there should only be a single)
         value = value.gsub(/(\r\n|\n\r|\r)/, "\n")
-        value = RedCloth.new(value).to_html
+        markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+        value = markdown.render(value)
 
         url_regex = '(\w+:\/\/[^ |<]+)'
         email_regex = '([\w._%+-]+@[\w.-]+\.[\w]{2,4})'

--- a/app/views/configure/section.html.haml
+++ b/app/views/configure/section.html.haml
@@ -13,7 +13,7 @@
             = fields_for "setting[]" do |f|
               = f.text_field :value
               .form_example
-                = RedCloth.new(@setting.explanation).to_html.gsub("&#8220;", "\"").gsub("&#8221;", "\"").gsub("&#8217;", "'").gsub("&#8216;", "'").gsub("‘", "'").gsub("’", "'")
+                = Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(@setting.explanation)
         - else
           = fields_for "setting[]" do |f|
             = f.hidden_field :value


### PR DESCRIPTION
Redoing #83 (which has merge conflicts)

Upgrade rails 3 to latest release and put `bundle-audit` in place to
ensure that the team is alerted about gems with known security problems
before they are checked-in.

* Run bundle-audit for each build in CI
* Upgrade to rails 3.2.21
* Replace unmtainained `RedCloth` gem with `redcarpet` (which is maintained)
* Use `https://` URLS to get gems via git repos (instead of less secure `git://` protocol)

 Conflicts:
	Gemfile
	Gemfile.lock

Author:    Eoin Kelly <eoin@rabidtech.co.nz>
Date:      Fri Jun 5 09:59:56 2015 +1200

On branch improve-security