### PR TITLE
Disable registration at client request

### DIFF
--- a/app/views/layouts/_user_nav.html.haml
+++ b/app/views/layouts/_user_nav.html.haml
@@ -3,7 +3,6 @@
   - account_hash = { :controller => 'account' }
 
   - if !logged_in?
-    %li.first= link_to_register(t('layouts.application.register'), account_hash.merge({ urlified_name: 'site', action: 'signup' }), { :tabindex => '2' })
     %li= link_to_login(t('layouts.application.login'), account_hash.merge({ urlified_name: 'site', action: 'login' }), { :tabindex => '2' })
 
   - else


### PR DESCRIPTION
Clients have requested that we disable registration of new users in preparation of their migration to a new system.